### PR TITLE
changed the filter for teams query by district

### DIFF
--- a/src/server/api/routers/teams.ts
+++ b/src/server/api/routers/teams.ts
@@ -9,19 +9,11 @@ export const teamsRouter = createTRPCRouter({
     .query(async ({ ctx, input }) => {
       if (input.districtId === "Global") {
         return await ctx.prisma.team.findMany({
-          where: {
-            global_ranking: {
-              not: null,
-            },
-          },
           orderBy: { global_ranking: "desc" },
         });
       } else {
         return await ctx.prisma.team.findMany({
           where: {
-            district_ranking: {
-              not: null,
-            },
             districtId: input.districtId,
           },
           orderBy: { district_ranking: "desc" },


### PR DESCRIPTION
- Changed the query for the request to get all teams within a specific district
- Before, it requested all teams without a 'null' ranking. Now, it returns all teams regardless of ranking